### PR TITLE
CLI: use argparse, clearer logging logic

### DIFF
--- a/bagit_profile.py
+++ b/bagit_profile.py
@@ -348,7 +348,7 @@ def _main():
     parser.add_argument('--loglevel', default='INFO', choices=('DEBUG', 'INFO', 'ERROR'), help="Log level. Default: %(default)s")
     parser.add_argument('--file', help="Load profile from FILE, not by URL. Default: %(default)s.")
     parser.add_argument('--report', action='store_true', help="Print validation report. Default: %(default)s")
-    parser.add_argument('--skip-serialization', action='store_true', help="Skip serialization validation. Default: %(default)s")
+    parser.add_argument('--skip', action='append', default=[], help="Skip validation steps. Default: %(default)s", choices=('serialization', 'profile'))
     parser.add_argument('profile_url', nargs=1)
     parser.add_argument('bagit_path', nargs=1)
 
@@ -370,7 +370,7 @@ def _main():
     bag = bagit.Bag(bagit_path)  # pylint: disable=no-member
 
     # Validate 'Serialization' and 'Accept-Serialization', then perform general validation.
-    if not args.skip_serialization:
+    if 'serialization' not in args.skip:
         if profile.validate_serialization(bagit_path):
             print("✓ Serialization validates")
         else:
@@ -378,13 +378,14 @@ def _main():
             sys.exit(1)
 
     # Validate the rest of the profile.
-    if profile.validate(bag):
-        print("✓ Validates against %s" % profile_url)
-    else:
-        print("✗ Does not validate against %s" % profile_url)
-        if args.report:
-            print(profile.report)
-        sys.exit(2)
+    if 'profile' not in args.skip:
+        if profile.validate(bag):
+            print("✓ Validates against %s" % profile_url)
+        else:
+            print("✗ Does not validate against %s" % profile_url)
+            if args.report:
+                print(profile.report)
+            sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/bagit_profile.py
+++ b/bagit_profile.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 
 """
 A simple Python module for validating BagIt profiles. See
@@ -372,17 +374,17 @@ def _main():
     # Validate 'Serialization' and 'Accept-Serialization', then perform general validation.
     if 'serialization' not in args.skip:
         if profile.validate_serialization(bagit_path):
-            print("✓ Serialization validates")
+            print(u"✓ Serialization validates")
         else:
-            print("✗ Serialization does not validate")
+            print(u"✗ Serialization does not validate")
             sys.exit(1)
 
     # Validate the rest of the profile.
     if 'profile' not in args.skip:
         if profile.validate(bag):
-            print("✓ Validates against %s" % profile_url)
+            print(u"✓ Validates against %s" % profile_url)
         else:
-            print("✗ Does not validate against %s" % profile_url)
+            print(u"✗ Does not validate against %s" % profile_url)
             if args.report:
                 print(profile.report)
             sys.exit(2)

--- a/bagit_profile.py
+++ b/bagit_profile.py
@@ -342,12 +342,12 @@ def _main():
     parser = ArgumentParser(description="Validate BagIt bags against BagIt profiles")
 
     parser.add_argument('--version', action='version', version='%(prog)s, v' + get_distribution('bagit_profile').version)
-    parser.add_argument('--quiet', action='store_true', help="Suppress all output except errors")
-    parser.add_argument('--log', dest='logdir', help="Log directory")
-    parser.add_argument('--no-logfile', action='store_true', help="Do not log to a log file")
-    parser.add_argument('--loglevel', help="Loglevel", default='INFO', choices=('DEBUG', 'INFO', 'ERROR'))
-    parser.add_argument('--file', help="Load profile from this file, not by its URL.")
-    parser.add_argument('--report', action='store_true', help="Print validation report")
+    parser.add_argument('--quiet', action='store_true', help="Suppress all output except errors. Default: %(default)s")
+    parser.add_argument('--log', dest='logdir', help="Log directory. Default: %(default)s")
+    parser.add_argument('--no-logfile', action='store_true', help="Do not log to a log file. Default: %(default)s")
+    parser.add_argument('--loglevel', default='INFO', choices=('DEBUG', 'INFO', 'ERROR'), help="Log level. Default: %(default)s")
+    parser.add_argument('--file', help="Load profile from FILE, not by URL. Default: %(default)s.")
+    parser.add_argument('--report', action='store_true', help="Print validation report. Default: %(default)s")
     parser.add_argument('profile_url', nargs=1)
     parser.add_argument('bagit_path', nargs=1)
 

--- a/bagit_profile.py
+++ b/bagit_profile.py
@@ -348,6 +348,7 @@ def _main():
     parser.add_argument('--loglevel', default='INFO', choices=('DEBUG', 'INFO', 'ERROR'), help="Log level. Default: %(default)s")
     parser.add_argument('--file', help="Load profile from FILE, not by URL. Default: %(default)s.")
     parser.add_argument('--report', action='store_true', help="Print validation report. Default: %(default)s")
+    parser.add_argument('--skip-serialization', action='store_true', help="Skip serialization validation. Default: %(default)s")
     parser.add_argument('profile_url', nargs=1)
     parser.add_argument('bagit_path', nargs=1)
 
@@ -369,11 +370,12 @@ def _main():
     bag = bagit.Bag(bagit_path)  # pylint: disable=no-member
 
     # Validate 'Serialization' and 'Accept-Serialization', then perform general validation.
-    if profile.validate_serialization(bagit_path):
-        print("✓ Serialization validates")
-    else:
-        print("✗ Serialization does not validate")
-        sys.exit(1)
+    if not args.skip_serialization:
+        if profile.validate_serialization(bagit_path):
+            print("✓ Serialization validates")
+        else:
+            print("✗ Serialization does not validate")
+            sys.exit(1)
 
     # Validate the rest of the profile.
     if profile.validate(bag):

--- a/bagit_profile.py
+++ b/bagit_profile.py
@@ -347,6 +347,7 @@ def _main():
     parser.add_argument('--no-logfile', action='store_true', help="Do not log to a log file")
     parser.add_argument('--loglevel', help="Loglevel", default='INFO', choices=('DEBUG', 'INFO', 'ERROR'))
     parser.add_argument('--file', help="Load profile from this file, not by its URL.")
+    parser.add_argument('--report', action='store_true', help="Print validation report")
     parser.add_argument('profile_url', nargs=1)
     parser.add_argument('bagit_path', nargs=1)
 
@@ -379,6 +380,8 @@ def _main():
         print("✓ Validates against %s" % profile_url)
     else:
         print("✗ Does not validate against %s" % profile_url)
+        if args.report:
+            print(profile.report)
         sys.exit(2)
 
 


### PR DESCRIPTION
* optparse is deprecated
* logging logic was broken (logging to file could not be disabled / logging to console not be enabled)
* version flag
* support variant of constructor which doesn't require fetching URL
* exits `1` for serialization error
* exits `2` for validation error

It should be backwards-compatible to not break existing scripts.